### PR TITLE
Modules folder names requirement removed

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -22,6 +22,11 @@ function api(sharedDir, targetDir, moduleList) {
       return fs.statSync(item).isDirectory();
     });
 
+  var MODULES = DIRS.map(function (dir) {
+    var pkg = readPackageJson(dir) || {};
+    return {name: pkg.name, folder: dir};
+  }).filter(function (pkg) {return pkg.name;});
+
   var LINKED = {};
 
   function linkDir(dir, name) {
@@ -38,24 +43,53 @@ function api(sharedDir, targetDir, moduleList) {
     LINKED[dir] = true;
   }
 
-  function link(dir) {
-    var i = 0;
-    var pkg;
-
+  function readPackageJson(dir) {
     try {
-      pkg = JSON.parse(fs.readFileSync(dir + '/package.json', 'utf-8'));
+      return pkg = JSON.parse(fs.readFileSync(dir + '/package.json', 'utf-8'));
     } catch (err) {
       console.log(chalk.red('`') + chalk.cyan(dir) + chalk.red('` ignored due to missing or erroneous package.json'));
       return;
     }
+  }
+
+  function find(array, criterias) {
+    var arrayLength = array.length;
+    var i=0;
+    var result;
+    criteriasKeys = Object.keys(criterias);
+    criteriasKeyslength = criteriasKeys.length;
+
+    for (; i<arrayLength; i++) {
+      var j=0;
+      var criteriasRespected = true;
+      var elt = array[i];
+
+      for (; j<criteriasKeyslength; j++) {
+        var criteriaKey = criteriasKeys[j];
+        if (elt[criteriaKey] !== criterias[criteriaKey]) {
+          criteriasRespected = false;
+          break;
+        }
+      }
+
+      if (criteriasRespected) return elt;
+    }
+  }
+
+  function link(dir) {
+    var i = 0;
+    var pkg = readPackageJson(dir);
 
     var dependencies = pkg.dependencies || {};
     dependencies = Object.keys(dependencies);
-    var shared_dependencies = dependencies.filter(function (item) {
-      return DIRS.indexOf(sharedDir + item) !== -1;
-    }).map(function (item) {
-      return sharedDir + item;
+    var shared_dependencies = dependencies.map(function (dependency) {
+      return find(MODULES, {name: dependency});
+    }).filter(function (module) {
+      return module;
+    }).map(function (module) {
+      return module.folder;
     });
+
     if (shared_dependencies.length > 0) {
       console.log(chalk.green(dir + ' has shared dependencies '), shared_dependencies);
       for (i = 0; i < shared_dependencies.length; i++) {


### PR DESCRIPTION
The following requirement is no longer necessary: 
"the name of module folders matches the module name in the package.json"
