### PR TITLE
Support for npm link options, removed hardcoded usage of --production

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install npm-link-shared -g
 
 ## Changelog
 
+v?     (2016-07-01) - Support for npm link options, removed hardcoded usage of `--production`
+
 v0.3.0 (2016-03-25) - Support for @scope packages. For example, `@scope/my-package`.
 
 v0.2.1 (2016-01-12) - Thanks to @barroudjo, module folder names are now de-coupled from the names in the package.json. So any name can be used as a folder name.
@@ -52,6 +54,20 @@ For example:
 ```
 
 this links modules `my-module1` and `my-module2` located in the `internal_modules` directory to the `my-project` dir. Only these two modules are installed but their dependencies are resolved against the entire `internal_modules` directory.
+
+### Define options passed to npm link
+
+```
+  npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-option> [--<npm-link-option>]];
+```
+
+For example:
+
+```
+  npm-link-shared /home/user/internal_modules/ /home/user/my-project --production
+```
+
+this prevents installation of devDependencies of shared modules by passing the production option to npm link (npm link --production)
 
 ## LICENSE
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [<module1..> [, <module2..>]]';
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-options>] [<module1..> [, <module2..>]]';
 
 if (argv._.length < 2) {
   console.log(usage);
@@ -33,4 +33,8 @@ if (argv._.length > 2) {
   }
 }
 
-link(sharedDir, targetDir, moduleList);
+var optionList = Object.keys(argv).slice(1).map(function (optionName) {
+    return '--' + optionName + '=' + argv[optionName];
+});
+
+link(sharedDir, targetDir, moduleList, optionList);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-options>] [<module1..> [, <module2..>]]';
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
 
 if (argv._.length < 2) {
   console.log(usage);

--- a/lib/link.js
+++ b/lib/link.js
@@ -145,7 +145,7 @@ function api(sharedDir, targetDir, moduleList, optionList) {
       for (i = 0; i < shared_dependencies.length; i++) {
         var pkgDep = JSON.parse(fs.readFileSync(shared_dependencies[i] + '/package.json', 'utf-8'));
         var name = pkgDep.name;
-        console.log(chalk.gray('\t' + exec('npm link ' + name + ' --production', {
+        console.log(chalk.gray('\t' + exec('npm link ' + name + ' ' + options, {
           cwd: dir
         }).toString()));
       }

--- a/lib/link.js
+++ b/lib/link.js
@@ -4,13 +4,19 @@ var fs = require('fs');
 var path = require('path');
 var S = require('string');
 
-function api(sharedDir, targetDir, moduleList) {
+function api(sharedDir, targetDir, moduleList, optionList) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
 
+  if (optionList.length > 0) {
+      console.log(chalk.green('Using the following options'), optionList);
+  }
+
   console.log(chalk.green('Restricted to the following modules'),
     moduleList.length === 0 ? 'All' : moduleList);
+
+  var options = optionList.join(' ');
 
   var sharedDirContent = fs
     .readdirSync(sharedDir);
@@ -70,11 +76,11 @@ function api(sharedDir, targetDir, moduleList) {
   function linkDir(dir, name) {
     console.log(chalk.green('\n\nLinking '  + dir));
 
-    console.log(chalk.gray('\t' + exec('npm link --production', {
+    console.log(chalk.gray('\t' + exec('npm link ' + options, {
       cwd: dir
     }).toString()));
 
-    console.log(chalk.gray('\t' + exec('npm link ' + name + ' --production', {
+    console.log(chalk.gray('\t' + exec('npm link ' + name + ' ' + options, {
       cwd: targetDir
     }).toString()));
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -4,11 +4,12 @@ var fs = require('fs');
 var path = require('path');
 var S = require('string');
 
-function api(sharedDir, targetDir, moduleList, optionList = []) {
+function api(sharedDir, targetDir, moduleList, optionList) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
 
+  optionList = optionList ? optionList : [];
   if (optionList.length > 0) {
       console.log(chalk.green('Using the following options'), optionList);
   }

--- a/lib/link.js
+++ b/lib/link.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var S = require('string');
 
-function api(sharedDir, targetDir, moduleList, optionList) {
+function api(sharedDir, targetDir, moduleList, optionList = []) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));

--- a/test/basic.js
+++ b/test/basic.js
@@ -7,20 +7,29 @@ describe('npm-link-shared', function() {
 
   it('should install dependencies via linking', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target', []);
+    link(base + '/test/shared_modules/', base + '/test/target', [], [ '--production' ]);
     assert(fs.existsSync(base + '/test/target/node_modules/module-a'), 'module-a does not exist');
     assert(fs.existsSync(base + '/test/target/node_modules/module-b'), 'module-b does not exist');
     assert(fs.existsSync(base + '/test/target/node_modules/module-c'), 'module-c does not exist');
     assert(fs.existsSync(base + '/test/target/node_modules/@scope/module-d'), '@scope/module-d does not exist');
-    assert(fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/lodash'), 'lodash does not exist');
-    assert(!fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/chai'), 'lodash does not exist');
-    assert(fs.existsSync(base + '/test/target/node_modules/module-c/node_modules/lodash'), 'lodash does not exist');
+    assert(
+        fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/lodash'),
+        'lodash does not exist in module-b'
+    );
+    assert(
+        !fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/chai'),
+        'chai does exist'
+    );
+    assert(
+        fs.existsSync(base + '/test/target/node_modules/module-c/node_modules/lodash'),
+        'lodash does not exist in module-c'
+    );
     done();
   });
 
   it('should install dependencies via linking and respect restrictions on modules', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target_single', ['module-c']);
+    link(base + '/test/shared_modules/', base + '/test/target_single', ['module-c'], [ '--production' ]);
     assert(fs.existsSync(base + '/test/target_single/node_modules/module-c'), 'module-c does not exist');
     done();
   });

--- a/test/scoped.js
+++ b/test/scoped.js
@@ -6,7 +6,7 @@ describe('scoped-modules', function() {
   this.timeout(30000);
   it('should install dependencies via linking and respect restrictions on modules', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target_single', [ '@scope/module-d' ]);
+    link(base + '/test/shared_modules/', base + '/test/target_single', [ '@scope/module-d' ], [ '--production' ]);
     assert(fs.existsSync(base + '/test/target_single/node_modules/@scope/module-d'), '@scope/module-d does not exist');
     done();
   });


### PR DESCRIPTION
Hi
### Define options passed to npm link

```
  npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-option> [--<npm-link-option>]];
```

For example:

```
  npm-link-shared /home/user/internal_modules/ /home/user/my-project --production
```

this prevents installation of devDependencies of shared modules by passing the production option to npm link (npm link --production)

This also works in combination with defining specific modules like that:

```
npm-link-shared <shared-modules-dir> <target-installation-dir>  [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]];
```
