### PR TITLE
Include local dev dependencies

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -4,6 +4,17 @@ var fs = require('fs');
 var path = require('path');
 var S = require('string');
 
+Array.prototype.unique = function () {
+    var n = {}, r = [];
+    for (var i = 0; i < this.length; i++) {
+        if (!n[this[i]]) {
+            n[this[i]] = true;
+            r.push(this[i]);
+        }
+    }
+    return r;
+}
+
 function api(sharedDir, targetDir, moduleList, optionList) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
@@ -16,6 +27,13 @@ function api(sharedDir, targetDir, moduleList, optionList) {
 
   console.log(chalk.green('Restricted to the following modules'),
     moduleList.length === 0 ? 'All' : moduleList);
+
+  //determine if we should include shared local dev dependencies in the linking
+  var includeDev = false;
+  if(optionList.indexOf("--includeDev") >= 0){
+      includeDev = true;
+      optionList.splice(optionList.indexOf("--includeDev"), 1);
+  }
 
   var options = optionList.join(' ');
 
@@ -127,6 +145,11 @@ function api(sharedDir, targetDir, moduleList, optionList) {
 
     var dependencies = pkg.dependencies || {};
     dependencies = Object.keys(dependencies);
+    if(includeDev){
+      var devDependencies = pkg.devDependencies || {};
+      devDependencies = Object.keys(devDependencies);
+      dependencies = dependencies.concat(dependencies, devDependencies).unique();
+    }
     var shared_dependencies = dependencies.map(function (dependency) {
       return find(MODULES, {name: dependency});
     }).filter(function (module) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var fs = require('fs');
 
 describe('npm-link-shared', function() {
-  this.timeout(30000);
+  this.timeout(60000);
 
   it('should install dependencies via linking', function(done) {
     var base = process.cwd();
@@ -31,6 +31,15 @@ describe('npm-link-shared', function() {
     var base = process.cwd();
     link(base + '/test/shared_modules/', base + '/test/target_single', ['module-c'], [ '--production' ]);
     assert(fs.existsSync(base + '/test/target_single/node_modules/module-c'), 'module-c does not exist');
+    done();
+  });
+
+  it('should also install local dev dependencies via linking', function(done) {
+    var base = process.cwd();
+    link(base + '/test/shared_modules/', base + '/test/target_dev_dependency', ['module-c', 'module-b'], [ '--production --includeDev' ]);
+    assert(fs.existsSync(base + '/test/target_dev_dependency/node_modules/module-c'), 'module-c does not exist');
+    assert(fs.existsSync(base + '/test/target_dev_dependency/node_modules/module-b'), 'module-b (included as a local dev dependency) does not exist');
+    
     done();
   });
 });

--- a/test/target_dev_dependency/package.json
+++ b/test/target_dev_dependency/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "target-single",
+  "version": "1.0.0",
+  "description": "Target project for a single package",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/OrKoN/npm-link-shared.git"
+  },
+  "private": "true",
+  "dependencies": {
+    "module-c": "*"
+  },
+  "devDependencies": {
+    "module-b": "*"
+  }
+}


### PR DESCRIPTION
We have a problem where we have a few shared, local dependencies, but they are dev dependencies, which get packaged into a production library.
With the current version of npm-link-shared, they were not included in the linking chain. I believe this to be a fairly common approach, so I created a pull request with a suggested solution to include a new option --includeDev to also include dev dependencies to recurse down the dependency tree, but not to include in the npm link [module] call (--production is still used).
This includes an update to the test which adds a dev dependency and checks if it is correctly linked.
Using an extra option to prevent existing logic to break.