### PR TITLE
Add support for yarn, improve filter test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ node_js:
   - "5"
   - "6"
 
+before_script:
+  - npm install -g yarn
+
 script:
   - npm run test

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ npm install npm-link-shared -g
 
 ## Changelog
 
-v0.3.3 (2016-07-01) - Support for npm link options, removed hardcoded usage of `--production`
+v0.4.0 (2017-03-13) - Support for changing executable to yarn with `--yarn`.
+
+v0.3.3 (2016-07-01) - Support for npm link options, removed hardcoded usage of `--production`.
 
 v0.3.0 (2016-03-25) - Support for @scope packages. For example, `@scope/my-package`.
 
@@ -68,6 +70,24 @@ For example:
 ```
 
 this prevents installation of devDependencies of shared modules by passing the production option to npm link (npm link --production)
+
+### Use yarn instead
+
+```
+  npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn];
+```
+
+For example:
+
+```
+  npm-link-shared /home/user/internal_modules/ /home/user/my-project --yarn
+```
+
+this works in conjunction with all other options
+
+## Developing
+
+To run tests successfully, you must have both npm and yarn in your `$PATH`.
 
 ## LICENSE
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
 
 if (argv._.length < 2) {
   console.log(usage);
@@ -33,8 +33,13 @@ if (argv._.length > 2) {
   }
 }
 
-var optionList = Object.keys(argv).slice(1).map(function (optionName) {
+var executable = argv['yarn'] ? 'yarn' : 'npm';
+
+delete(argv['_']);
+delete(argv['yarn']);
+
+var optionList = Object.keys(argv).map(function (optionName) {
     return '--' + optionName + '=' + argv[optionName];
 });
 
-link(sharedDir, targetDir, moduleList, optionList);
+link(sharedDir, targetDir, moduleList, optionList, executable);

--- a/lib/link.js
+++ b/lib/link.js
@@ -15,10 +15,15 @@ Array.prototype.unique = function () {
     return r;
 }
 
-function api(sharedDir, targetDir, moduleList, optionList) {
+function api(sharedDir, targetDir, moduleList, optionList, executable) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
+
+  executable = executable || 'npm';
+  if (executable != 'npm') {
+    console.log(chalk.green('With ') + chalk.cyan(executable));
+  }
 
   optionList = optionList ? optionList : [];
   if (optionList.length > 0) {
@@ -95,11 +100,11 @@ function api(sharedDir, targetDir, moduleList, optionList) {
   function linkDir(dir, name) {
     console.log(chalk.green('\n\nLinking '  + dir));
 
-    console.log(chalk.gray('\t' + exec('npm link ' + options, {
+    console.log(chalk.gray('\t' + exec(executable + ' link ' + options, {
       cwd: dir
     }).toString()));
 
-    console.log(chalk.gray('\t' + exec('npm link ' + name + ' ' + options, {
+    console.log(chalk.gray('\t' + exec(executable + ' link ' + name + ' ' + options, {
       cwd: targetDir
     }).toString()));
 
@@ -168,7 +173,7 @@ function api(sharedDir, targetDir, moduleList, optionList) {
       for (i = 0; i < shared_dependencies.length; i++) {
         var pkgDep = JSON.parse(fs.readFileSync(shared_dependencies[i] + '/package.json', 'utf-8'));
         var name = pkgDep.name;
-        console.log(chalk.gray('\t' + exec('npm link ' + name + ' ' + options, {
+        console.log(chalk.gray('\t' + exec(executable + ' link ' + name + ' ' + options, {
           cwd: dir
         }).toString()));
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-link-shared",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "links a folder of local modules with inter-dependencies to the target directory",
   "main": "index.js",
   "scripts": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,6 +30,8 @@ describe('npm-link-shared', function() {
   it('should install dependencies via linking and respect restrictions on modules', function(done) {
     var base = process.cwd();
     link(base + '/test/shared_modules/', base + '/test/target_single', ['module-c'], [ '--production' ]);
+    assert(!fs.existsSync(base + '/test/target_single/node_modules/module-a'), 'module-a exists but should have been ignored');
+    assert(!fs.existsSync(base + '/test/target_single/node_modules/module-b'), 'module-b exists but should have been ignored');
     assert(fs.existsSync(base + '/test/target_single/node_modules/module-c'), 'module-c does not exist');
     done();
   });

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,26 +5,42 @@ var fs = require('fs');
 describe('npm-link-shared', function() {
   this.timeout(60000);
 
-  it('should install dependencies via linking', function(done) {
+  function basic_test(use_yarn, done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target', [], [ '--production' ]);
-    assert(fs.existsSync(base + '/test/target/node_modules/module-a'), 'module-a does not exist');
-    assert(fs.existsSync(base + '/test/target/node_modules/module-b'), 'module-b does not exist');
-    assert(fs.existsSync(base + '/test/target/node_modules/module-c'), 'module-c does not exist');
-    assert(fs.existsSync(base + '/test/target/node_modules/@scope/module-d'), '@scope/module-d does not exist');
+    var target = base + '/test/target';
+
+    if (use_yarn) {
+      target = target + '_yarn';
+      link(base + '/test/shared_modules/', target, [], [ '--production' ], 'yarn');
+    } else {
+      link(base + '/test/shared_modules/', target, [], [ '--production' ]);
+    }
+
+    assert(fs.existsSync(target + '/node_modules/module-a'), 'module-a does not exist');
+    assert(fs.existsSync(target + '/node_modules/module-b'), 'module-b does not exist');
+    assert(fs.existsSync(target + '/node_modules/module-c'), 'module-c does not exist');
+    assert(fs.existsSync(target + '/node_modules/@scope/module-d'), '@scope/module-d does not exist');
     assert(
-        fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/lodash'),
+        fs.existsSync(target + '/node_modules/module-b/node_modules/lodash'),
         'lodash does not exist in module-b'
     );
     assert(
-        !fs.existsSync(base + '/test/target/node_modules/module-b/node_modules/chai'),
+        !fs.existsSync(target + '/node_modules/module-b/node_modules/chai'),
         'chai does exist'
     );
     assert(
-        fs.existsSync(base + '/test/target/node_modules/module-c/node_modules/lodash'),
+        fs.existsSync(target + '/node_modules/module-c/node_modules/lodash'),
         'lodash does not exist in module-c'
     );
     done();
+  }
+
+  it('should install dependencies via linking', function(done) {
+    basic_test(false, done);
+  });
+
+  it('should install dependencies via linking using yarn', function(done) {
+    basic_test(true, done);
   });
 
   it('should install dependencies via linking and respect restrictions on modules', function(done) {

--- a/test/target_yarn/package.json
+++ b/test/target_yarn/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "target-yarn",
+  "version": "1.0.0",
+  "description": "Target project for yarn link",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/OrKoN/npm-link-shared.git"
+  },
+  "private": "true",
+  "dependencies": {
+    "module-a": "*"
+  }
+}


### PR DESCRIPTION
Yarn support for folks who want slightly faster linking :smile: 

* Includes a simple test for linking with yarn, requires yarn binary in `$PATH` (`npm install -g yarn`)
* Should be entirely backwards compatible, both lib and cli. Doesn't even change output unless `--yarn` is given, in case any user parses output in their CI system.
* Took the liberty of upping the version in package.json to 0.4.0 in accord with semver 2.0
* Lib can be given any executable, but cli will only pass npm or yarn.