### PR TITLE
Support graceful exit if dirs missing and --allow-no-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install npm-link-shared -g
 
 ## Changelog
 
-v0.5.0 (2017-03-27) - Support for graceful exit if `--allow-no-dir` is used and shared modules or target directories do not exist.
+v0.5.0 (2017-03-29) - **BREAKING CHANGES**: The lib/api function's arguments have been revamped. The previously undocumented argument --includeDev is now --include-dev to be consistent with other arguments. We now print a warning and exit gracefully if either the shared or target directory do not exist.
 
 v0.4.0 (2017-03-13) - Support for changing executable to yarn with `--yarn`. **Use at your own risk!** `yarn link` is not yet functionally equivalent to `npm link`.
 
@@ -34,7 +34,7 @@ v0.1.6 (2015-04-20) - Removed unneeded npm dependency. Added a possibility to de
 ## Usage
 
 ```
-  npm-link-shared <local-modules-folder> <target-dir>
+  npm-link-shared <shared-modules-dir> <target-installation-dir> [<module1..> [, <module2..>]] [--yarn] [--include-dev] [--<npm-link-option> [--<npm-link-option>]]
 ```
 
 For example:
@@ -43,51 +43,41 @@ For example:
   npm-link-shared /home/user/internal_modules/ /home/user/my-project
 ```
 
-this links all modules located in the `internal_modules` directory to the `my-project` dir.
+This links all modules located in the `internal_modules` directory to the `my-project` dir.
 
 ### Define specific modules to install
-
-```
-npm-link-shared <shared-modules-dir> <target-installation-dir> [<module1..> [, <module2..>]];
-```
-
-For example:
 
 ```
   npm-link-shared /home/user/internal_modules/ /home/user/my-project my-module1 my-module2
 ```
 
-this links modules `my-module1` and `my-module2` located in the `internal_modules` directory to the `my-project` dir. Only these two modules are installed but their dependencies are resolved against the entire `internal_modules` directory.
+This links modules `my-module1` and `my-module2` located in the `internal_modules` directory to the `my-project` dir. Only these two modules are installed but their dependencies are resolved against the entire `internal_modules` directory.
 
 ### Define options passed to npm link
-
-```
-  npm-link-shared <shared-modules-dir> <target-installation-dir> [--<npm-link-option> [--<npm-link-option>]];
-```
-
-For example:
 
 ```
   npm-link-shared /home/user/internal_modules/ /home/user/my-project --production
 ```
 
-this prevents installation of devDependencies of shared modules by passing the production option to npm link (npm link --production)
+This prevents installation of devDependencies of shared modules by passing the production option to npm link (npm link --production).
 
 ### Use yarn instead
 
 **NOTE:** `yarn link` is currently functionally different from `npm link`, and should not be considered stable. Use at your own risk until the yarn project has stabilized.
 
 ```
-  npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn];
-```
-
-For example:
-
-```
   npm-link-shared /home/user/internal_modules/ /home/user/my-project --yarn
 ```
 
-this works in conjunction with all other options
+This works in conjunction with all other options.
+
+### Also link devDependencies
+
+```
+  npm-link-shared /home/user/internal_modules/ /home/user/my-project --include-dev
+```
+
+Ordinarily, only packages found under the dependencies key in a project's `package.json` are linked. With this option, devDependencies are also linked.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install npm-link-shared -g
 
 ## Changelog
 
+v0.5.0 (2017-03-27) - Support for graceful exit if `--allow-no-dir` is used and shared modules or target directories do not exist.
+
 v0.4.0 (2017-03-13) - Support for changing executable to yarn with `--yarn`. **Use at your own risk!** `yarn link` is not yet functionally equivalent to `npm link`.
 
 v0.3.3 (2016-07-01) - Support for npm link options, removed hardcoded usage of `--production`.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-// TODO document the include-dev switch, note the breaking change from includeDev
 var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [<module1..> [, <module2..>]] [--yarn] [--include-dev] [--<npm-link-option> [--<npm-link-option>]]';
 
 if (argv._.length < 2) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--allow-no-dir] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
 
 if (argv._.length < 2) {
   console.log(usage);
@@ -38,10 +38,9 @@ var allowNoDir = argv['allow-no-dir'] ? true : false;
 
 delete(argv['_']);
 delete(argv['yarn']);
-delete(argv['allow-nodir']);
 
 var optionList = Object.keys(argv).map(function (optionName) {
     return '--' + optionName + '=' + argv[optionName];
 });
 
-link(sharedDir, targetDir, moduleList, optionList, executable, allowNoDir);
+link(sharedDir, targetDir, moduleList, optionList, executable);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
+// TODO document the include-dev switch, note the breaking change from includeDev
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [<module1..> [, <module2..>]] [--yarn] [--include-dev] [--<npm-link-option> [--<npm-link-option>]]';
 
 if (argv._.length < 2) {
   console.log(usage);
@@ -26,21 +27,27 @@ if (!sharedDir || !targetDir) {
 sharedDir = S(sharedDir).ensureRight('/').s;
 targetDir = S(targetDir).ensureRight('/').s;
 
-var moduleList = [];
+var moduleWhiteList = [];
 if (argv._.length > 2) {
   for (var i = 2; i < argv._.length; i++) {
-    moduleList.push(argv._[i]);
+    moduleWhiteList.push(argv._[i]);
   }
 }
 
 var executable = argv['yarn'] ? 'yarn' : 'npm';
-var allowNoDir = argv['allow-no-dir'] ? true : false;
+var includeDev = argv['include-dev'] ? true : false;
 
 delete(argv['_']);
 delete(argv['yarn']);
+delete(argv['include-dev']);
 
-var optionList = Object.keys(argv).map(function (optionName) {
+var linkOptions = Object.keys(argv).map(function (optionName) {
     return '--' + optionName + '=' + argv[optionName];
 });
 
-link(sharedDir, targetDir, moduleList, optionList, executable);
+link(sharedDir, targetDir, {
+  'moduleWhiteList': moduleWhiteList,
+  'executable': executable,
+  'includeDev': includeDev,
+  'linkOptions': linkOptions
+});

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var S = require('string');
 var argv = require('minimist')(process.argv.slice(2));
 var link = require('./lib/link');
 
-var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
+var usage = 'Usage: npm-link-shared <shared-modules-dir> <target-installation-dir> [--yarn] [--allow-no-dir] [--<npm-link-option> [--<npm-link-option>]] [<module1..> [, <module2..>]]';
 
 if (argv._.length < 2) {
   console.log(usage);
@@ -34,12 +34,14 @@ if (argv._.length > 2) {
 }
 
 var executable = argv['yarn'] ? 'yarn' : 'npm';
+var allowNoDir = argv['allow-no-dir'] ? true : false;
 
 delete(argv['_']);
 delete(argv['yarn']);
+delete(argv['allow-nodir']);
 
 var optionList = Object.keys(argv).map(function (optionName) {
     return '--' + optionName + '=' + argv[optionName];
 });
 
-link(sharedDir, targetDir, moduleList, optionList, executable);
+link(sharedDir, targetDir, moduleList, optionList, executable, allowNoDir);

--- a/lib/link.js
+++ b/lib/link.js
@@ -15,7 +15,7 @@ Array.prototype.unique = function () {
     return r;
 }
 
-function api(sharedDir, targetDir, moduleList, optionList, executable, allowNoDir) {
+function api(sharedDir, targetDir, moduleList, optionList, executable) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
@@ -42,31 +42,29 @@ function api(sharedDir, targetDir, moduleList, optionList, executable, allowNoDi
 
   var options = optionList.join(' ');
 
-  // Get sharedDir contents. Ensure we exit gracefully if
-  // sharedDir does not exist and allowNoDir is set
+  // Get sharedDir contents
+  // Ensure we exit gracefully if sharedDir does not exist
   try {
-    var sharedDirContent = fs
-      .readdirSync(sharedDir);
+    var sharedDirContent = fs.readdirSync(sharedDir);
   } catch (err) {
-    if (err.code == 'ENOENT' && allowNoDir) {
-      console.log(chalk.green('Abandoning linking, directory does not exist: ') +
-        chalk.green('`') + chalk.red(targetDir) + chalk.green('`'));
+    if (err.code == 'ENOENT') {
+      console.log(chalk.yellow('Abandoning linking, directory does not exist: ') +
+        chalk.yellow('`') + chalk.red(targetDir) + chalk.yellow('`'));
       return;
     }
     throw err;
   }
 
-  // Ensure we exit gracefully if targetDir does not exist and allowNoDir is set
-  if (allowNoDir) {
-    try {
-      fs.readdirSync(targetDir);
-    } catch (err) {
-      if (err.code == 'ENOENT') {
-        console.log(chalk.green('Abandoning linking, directory does not exist: ') +
-          chalk.green('`') + chalk.red(targetDir) + chalk.green('`'));
-        return;
-      }
+  // Ensure we exit gracefully if targetDir does not exist
+  try {
+    fs.readdirSync(targetDir);
+  } catch (err) {
+    if (err.code == 'ENOENT') {
+      console.log(chalk.yellow('Abandoning linking, directory does not exist: ') +
+        chalk.yellow('`') + chalk.red(targetDir) + chalk.yellow('`'));
+      return;
     }
+    throw(err); // Some other error ocurred
   }
 
   var DIRS = sharedDirContent

--- a/lib/link.js
+++ b/lib/link.js
@@ -4,15 +4,15 @@ var fs = require('fs');
 var path = require('path');
 var S = require('string');
 
-Array.prototype.unique = function () {
-    var n = {}, r = [];
-    for (var i = 0; i < this.length; i++) {
-        if (!n[this[i]]) {
-            n[this[i]] = true;
-            r.push(this[i]);
-        }
+function unique_elements(arr) {
+  var n = {}, r = [];
+  for (var i = 0; i < arr.length; i++) {
+    if (!n[arr[i]]) {
+      n[arr[i]] = true;
+      r.push(arr[i]);
     }
-    return r;
+  }
+  return r;
 }
 
 function api(sharedDir, targetDir, options) {
@@ -183,7 +183,7 @@ function api(sharedDir, targetDir, options) {
       // We should include shared local dev dependencies in the linking
       var devDependencies = pkg.devDependencies || {};
       devDependencies = Object.keys(devDependencies);
-      dependencies = dependencies.concat(dependencies, devDependencies).unique();
+      dependencies = unique_elements(dependencies.concat(dependencies, devDependencies));
     }
     var shared_dependencies = dependencies.map(function (dependency) {
       return find(MODULES, {name: dependency});

--- a/lib/link.js
+++ b/lib/link.js
@@ -15,7 +15,7 @@ Array.prototype.unique = function () {
     return r;
 }
 
-function api(sharedDir, targetDir, moduleList, optionList, executable) {
+function api(sharedDir, targetDir, moduleList, optionList, executable, allowNoDir) {
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
@@ -42,8 +42,32 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
 
   var options = optionList.join(' ');
 
-  var sharedDirContent = fs
-    .readdirSync(sharedDir);
+  // Get sharedDir contents. Ensure we exit gracefully if
+  // sharedDir does not exist and allowNoDir is set
+  try {
+    var sharedDirContent = fs
+      .readdirSync(sharedDir);
+  } catch (err) {
+    if (err.code == 'ENOENT' && allowNoDir) {
+      console.log(chalk.green('Abandoning linking, directory does not exist: ') +
+        chalk.green('`') + chalk.red(targetDir) + chalk.green('`'));
+      return;
+    }
+    throw err;
+  }
+
+  // Ensure we exit gracefully if targetDir does not exist and allowNoDir is set
+  if (allowNoDir) {
+    try {
+      fs.readdirSync(targetDir);
+    } catch (err) {
+      if (err.code == 'ENOENT') {
+        console.log(chalk.green('Abandoning linking, directory does not exist: ') +
+          chalk.green('`') + chalk.red(targetDir) + chalk.green('`'));
+        return;
+      }
+    }
+  }
 
   var DIRS = sharedDirContent
     .filter(function (item) {

--- a/lib/link.js
+++ b/lib/link.js
@@ -15,32 +15,39 @@ Array.prototype.unique = function () {
     return r;
 }
 
-function api(sharedDir, targetDir, moduleList, optionList, executable) {
+function api(sharedDir, targetDir, options) {
+  // Defaults
+  var opts = {
+    'moduleWhiteList': [],
+    'executable': 'npm',
+    'includeDev': false,
+    'linkOptions': []
+  };
+
+  // Override defaults with user provided options
+  options = options ? options : {};
+  Object.keys(options).forEach(function extend_opts(key) {
+    opts[key] = options[key];
+  });
+
+  // Pre-format arguments for `{npm,yarn} link` command
+  var link_options = opts.linkOptions.join(' ');
+
   console.log(chalk.green('Will be installing modules from `') +
     chalk.cyan(sharedDir) + chalk.green('` to `') +
     chalk.cyan(targetDir) + chalk.green('`...'));
 
-  executable = executable || 'npm';
-  if (executable != 'npm') {
-    console.log(chalk.green('With ') + chalk.cyan(executable));
+  if (opts.executable != 'npm') {
+    console.log(chalk.green('With ') + chalk.cyan(opts.executable));
   }
 
-  optionList = optionList ? optionList : [];
-  if (optionList.length > 0) {
-      console.log(chalk.green('Using the following options'), optionList);
+  if (opts.linkOptions.length > 0) {
+      console.log(chalk.green('Using the following link options'), opts.linkOptions);
   }
 
-  console.log(chalk.green('Restricted to the following modules'),
-    moduleList.length === 0 ? 'All' : moduleList);
-
-  //determine if we should include shared local dev dependencies in the linking
-  var includeDev = false;
-  if(optionList.indexOf("--includeDev") >= 0){
-      includeDev = true;
-      optionList.splice(optionList.indexOf("--includeDev"), 1);
+  if (opts.moduleWhiteList.length !== 0) {
+    console.log(chalk.green('Restricted to the following modules'), opts.moduleWhiteList);
   }
-
-  var options = optionList.join(' ');
 
   // Get sharedDir contents
   // Ensure we exit gracefully if sharedDir does not exist
@@ -49,10 +56,10 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
   } catch (err) {
     if (err.code == 'ENOENT') {
       console.log(chalk.yellow('Abandoning linking, directory does not exist: ') +
-        chalk.yellow('`') + chalk.red(targetDir) + chalk.yellow('`'));
+        chalk.yellow('`') + chalk.red(sharedDir) + chalk.yellow('`'));
       return;
     }
-    throw err;
+    throw err; // Some other error ocurred
   }
 
   // Ensure we exit gracefully if targetDir does not exist
@@ -64,7 +71,7 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
         chalk.yellow('`') + chalk.red(targetDir) + chalk.yellow('`'));
       return;
     }
-    throw(err); // Some other error ocurred
+    throw err; // Some other error ocurred
   }
 
   var DIRS = sharedDirContent
@@ -122,11 +129,11 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
   function linkDir(dir, name) {
     console.log(chalk.green('\n\nLinking '  + dir));
 
-    console.log(chalk.gray('\t' + exec(executable + ' link ' + options, {
+    console.log(chalk.gray('\t' + exec(opts.executable + ' link ' + link_options, {
       cwd: dir
     }).toString()));
 
-    console.log(chalk.gray('\t' + exec(executable + ' link ' + name + ' ' + options, {
+    console.log(chalk.gray('\t' + exec(opts.executable + ' link ' + name + ' ' + link_options, {
       cwd: targetDir
     }).toString()));
 
@@ -172,7 +179,8 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
 
     var dependencies = pkg.dependencies || {};
     dependencies = Object.keys(dependencies);
-    if(includeDev){
+    if(opts.includeDev){
+      // We should include shared local dev dependencies in the linking
       var devDependencies = pkg.devDependencies || {};
       devDependencies = Object.keys(devDependencies);
       dependencies = dependencies.concat(dependencies, devDependencies).unique();
@@ -195,7 +203,7 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
       for (i = 0; i < shared_dependencies.length; i++) {
         var pkgDep = JSON.parse(fs.readFileSync(shared_dependencies[i] + '/package.json', 'utf-8'));
         var name = pkgDep.name;
-        console.log(chalk.gray('\t' + exec(executable + ' link ' + name + ' ' + options, {
+        console.log(chalk.gray('\t' + exec(opts.executable + ' link ' + name + ' ' + link_options, {
           cwd: dir
         }).toString()));
       }
@@ -207,10 +215,10 @@ function api(sharedDir, targetDir, moduleList, optionList, executable) {
 
   MODULES
     .filter(function (item) { // install only explicitly set modules
-        if (moduleList.length === 0) {
+        if (opts.moduleWhiteList.length === 0) {
           return true;
         } else {
-          return moduleList.indexOf(item.name) !== -1;
+          return opts.moduleWhiteList.indexOf(item.name) !== -1;
         }
       })
     .forEach(function (item) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-link-shared",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "links a folder of local modules with inter-dependencies to the target directory",
   "main": "index.js",
   "scripts": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -61,25 +61,11 @@ describe('npm-link-shared', function() {
     done();
   });
 
-  it('should throw on missing directories if not allowNoDir', function(done) {
-    var base = process.cwd();
-    // These two ensure that we maintain backwards compatibility by
-    // throwing when a non-existing directory is used. This could help
-    // catching configuration mistakes in CI systems.
-    assert.throws(function noDirTestThrowOne() {
-      link(base + '/test/flarbatron/', base + '/test/target_single', [], []);
-    });
-    assert.throws(function noDirTestThrowTwo() {
-      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], []);
-    });
-    done();
-  });
-
-  it('should not throw on missing directories if allowNoDir', function(done) {
+  it('should exit cleanly on missing directories', function(done) {
     var base = process.cwd();
     assert.doesNotThrow(function noDirTestNoThrow() {
-      link(base + '/test/flarbatron/', base + '/test/target_single', [], [], 'npm', true);
-      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], [], 'npm', true);
+      link(base + '/test/flarbatron/', base + '/test/target_single', [], []);
+      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], []);
     });
     done();
   });

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,9 +11,14 @@ describe('npm-link-shared', function() {
 
     if (use_yarn) {
       target = target + '_yarn';
-      link(base + '/test/shared_modules/', target, [], [ '--production' ], 'yarn');
+      link(base + '/test/shared_modules/', target, {
+        'executable': 'yarn',
+        'linkOptions': ['--production']
+      });
     } else {
-      link(base + '/test/shared_modules/', target, [], [ '--production' ]);
+      link(base + '/test/shared_modules/', target, {
+        'linkOptions': ['--production']
+      });
     }
 
     assert(fs.existsSync(target + '/node_modules/module-a'), 'module-a does not exist');
@@ -45,7 +50,11 @@ describe('npm-link-shared', function() {
 
   it('should install dependencies via linking and respect restrictions on modules', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target_single', ['module-c'], [ '--production' ]);
+    var target = base + '/test/target_single';
+    link(base + '/test/shared_modules/', target, {
+      'moduleWhiteList': ['module-c'],
+      'linkOptions': ['--production']
+    });
     assert(!fs.existsSync(base + '/test/target_single/node_modules/module-a'), 'module-a exists but should have been ignored');
     assert(!fs.existsSync(base + '/test/target_single/node_modules/module-b'), 'module-b exists but should have been ignored');
     assert(fs.existsSync(base + '/test/target_single/node_modules/module-c'), 'module-c does not exist');
@@ -54,7 +63,12 @@ describe('npm-link-shared', function() {
 
   it('should also install local dev dependencies via linking', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target_dev_dependency', ['module-c', 'module-b'], [ '--production --includeDev' ]);
+    var target = base + '/test/target_dev_dependency';
+    link(base + '/test/shared_modules/', target, {
+      'moduleWhiteList': ['module-c', 'module-b'],
+      'linkOptions': ['--production'],
+      'includeDev': true
+    });
     assert(fs.existsSync(base + '/test/target_dev_dependency/node_modules/module-c'), 'module-c does not exist');
     assert(fs.existsSync(base + '/test/target_dev_dependency/node_modules/module-b'), 'module-b (included as a local dev dependency) does not exist');
     
@@ -64,8 +78,8 @@ describe('npm-link-shared', function() {
   it('should exit cleanly on missing directories', function(done) {
     var base = process.cwd();
     assert.doesNotThrow(function noDirTestNoThrow() {
-      link(base + '/test/flarbatron/', base + '/test/target_single', [], []);
-      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], []);
+      link(base + '/test/flarbatron/', base + '/test/target_single');
+      link(base + '/test/shared_modules/', base + '/test/flarbatron');
     });
     done();
   });

--- a/test/basic.js
+++ b/test/basic.js
@@ -60,4 +60,27 @@ describe('npm-link-shared', function() {
     
     done();
   });
+
+  it('should throw on missing directories if not allowNoDir', function(done) {
+    var base = process.cwd();
+    // These two ensure that we maintain backwards compatibility by
+    // throwing when a non-existing directory is used. This could help
+    // catching configuration mistakes in CI systems.
+    assert.throws(function noDirTestThrowOne() {
+      link(base + '/test/flarbatron/', base + '/test/target_single', [], []);
+    });
+    assert.throws(function noDirTestThrowTwo() {
+      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], []);
+    });
+    done();
+  });
+
+  it('should not throw on missing directories if allowNoDir', function(done) {
+    var base = process.cwd();
+    assert.doesNotThrow(function noDirTestNoThrow() {
+      link(base + '/test/flarbatron/', base + '/test/target_single', [], [], 'npm', true);
+      link(base + '/test/shared_modules/', base + '/test/flarbatron', [], [], 'npm', true);
+    });
+    done();
+  });
 });

--- a/test/scoped.js
+++ b/test/scoped.js
@@ -6,7 +6,12 @@ describe('scoped-modules', function() {
   this.timeout(30000);
   it('should install dependencies via linking and respect restrictions on modules', function(done) {
     var base = process.cwd();
-    link(base + '/test/shared_modules/', base + '/test/target_single', [ '@scope/module-d' ], [ '--production' ]);
+    var target = base + '/test/target_single';
+    link(base + '/test/shared_modules/', target, {
+      'moduleWhiteList': ['@scope/module-d'],
+      'linkOptions': ['--production'],
+      'includeDev': true
+    });
     assert(fs.existsSync(base + '/test/target_single/node_modules/@scope/module-d'), '@scope/module-d does not exist');
     done();
   });


### PR DESCRIPTION
Useful for my npm-link in docker workflow. Will probably do a writeup about it later on.

This commit introduces the first flag with multiple words in it, chose to go with choo-choo-train case, since the `--npm-link-option`s are written in that case.

I suggest refactoring the api function to use dictionary options later next time you break backwards compatibility. Something like

```js
function api(sharedDir, targetDir, options) {
  var opts = {
    'moduleList': [],
    'linkOptions': [], // previously "optionList"
    'executable': 'npm',
    'allowNoDir': false,
  };
  Object.keys(options).forEach(function extend_opts(key) {
    opts[key] = options[key];
  });

  // rest of function uses opts to access options
```

I guess this could be done without breaking backwards compat, but it'd be ugly.
